### PR TITLE
Add a check for if user loses permission for a cosmetic

### DIFF
--- a/core/src/main/java/be/isach/ultracosmetics/UltraCosmetics.java
+++ b/core/src/main/java/be/isach/ultracosmetics/UltraCosmetics.java
@@ -1,8 +1,8 @@
 package be.isach.ultracosmetics;
 
 import be.isach.ultracosmetics.command.CommandAliasManager;
-import be.isach.ultracosmetics.command.ultracosmetics.CommandManager;
 import be.isach.ultracosmetics.command.showcase.CommandShowcaseManager;
+import be.isach.ultracosmetics.command.ultracosmetics.CommandManager;
 import be.isach.ultracosmetics.config.MessageManager;
 import be.isach.ultracosmetics.config.NPCManager;
 import be.isach.ultracosmetics.config.SettingsManager;
@@ -19,7 +19,6 @@ import be.isach.ultracosmetics.mysql.MySqlConnectionManager;
 import be.isach.ultracosmetics.placeholderapi.PlaceholderHook;
 import be.isach.ultracosmetics.player.UltraPlayer;
 import be.isach.ultracosmetics.player.UltraPlayerManager;
-import be.isach.ultracosmetics.player.profile.CosmeticsProfile;
 import be.isach.ultracosmetics.player.profile.CosmeticsProfileManager;
 import be.isach.ultracosmetics.run.FallDamageManager;
 import be.isach.ultracosmetics.run.InvalidWorldChecker;

--- a/core/src/main/java/be/isach/ultracosmetics/UltraCosmetics.java
+++ b/core/src/main/java/be/isach/ultracosmetics/UltraCosmetics.java
@@ -253,12 +253,6 @@ public class UltraCosmetics extends JavaPlugin {
      */
     @Override
     public void onDisable() {
-        // TODO Purge Pet Names. (and Treasure Chests bugged holograms).
-        // TODO Use Metadatas for that!
-
-        for (CosmeticsProfile cp : cosmeticsProfileManager.getCosmeticsProfiles().values()) {
-            cp.save();
-        }
 
         if (playerManager != null) {
             playerManager.dispose();

--- a/core/src/main/java/be/isach/ultracosmetics/config/NPCManager.java
+++ b/core/src/main/java/be/isach/ultracosmetics/config/NPCManager.java
@@ -79,7 +79,7 @@ public class NPCManager {
                                 if (cp == null) {
                                     plugin.getCosmeticsProfileManager().initForPlayer(ultraPlayer);
                                 } else {
-                                    cp.loadToPlayer();
+                                    cp.loadToPlayerWithoutSaving();
                                 }
                             }
                         }

--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/Cosmetic.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/Cosmetic.java
@@ -44,6 +44,7 @@ public abstract class Cosmetic<T extends CosmeticType> extends BukkitRunnable im
     public void equip() { // TODO: Handle permissions and this NPC check correctly.
         if (!owner.getBukkitPlayer().hasPermission(getType().getPermission()) && !CitizensAPI.getNPCRegistry().isNPC(Bukkit.getEntity(ownerUniqueId))) { // Check if owner has correct permissions AND IS NOT AN NPC.
             getPlayer().sendMessage(MessageManager.getMessage("No-Permission"));
+            owner.removeCosmetic(category);
             return;
         }
 

--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/pets/Pet.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/pets/Pet.java
@@ -151,7 +151,6 @@ public abstract class Pet extends Cosmetic<PetType> implements Updatable {
 
         // Set this pet as the UltraPlayer's current pet
         getOwner().setCurrentPet(this);
-        getOwner().saveCosmeticsProfile();
     }
 
     public String getColorVariantFromFile() {

--- a/core/src/main/java/be/isach/ultracosmetics/player/profile/CosmeticsProfile.java
+++ b/core/src/main/java/be/isach/ultracosmetics/player/profile/CosmeticsProfile.java
@@ -3,12 +3,10 @@ package be.isach.ultracosmetics.player.profile;
 import be.isach.ultracosmetics.UltraCosmetics;
 import be.isach.ultracosmetics.UltraCosmeticsData;
 import be.isach.ultracosmetics.config.SettingsManager;
-import be.isach.ultracosmetics.cosmetics.mounts.Mount;
 import be.isach.ultracosmetics.cosmetics.suits.ArmorSlot;
 import be.isach.ultracosmetics.cosmetics.type.*;
 import be.isach.ultracosmetics.log.SmartLogger;
 import be.isach.ultracosmetics.player.UltraPlayer;
-import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.util.Arrays;

--- a/core/src/main/java/be/isach/ultracosmetics/player/profile/CosmeticsProfile.java
+++ b/core/src/main/java/be/isach/ultracosmetics/player/profile/CosmeticsProfile.java
@@ -228,7 +228,7 @@ public class CosmeticsProfile {
         SettingsManager settingsManager = SettingsManager.getData(uuid);
 
         // Update the UltraPlayer's cosmetic profile to match current UltraPlayer's settings
-        UpdateCosmeticsProfile(ultraPlayer);
+        updateCosmeticsProfile(ultraPlayer);
 
         settingsManager.set("enabled.gadget", enabledGadget != null ? enabledGadget.getConfigName() : "none");
         settingsManager.set("enabled.effect", enabledEffect != null ? enabledEffect.getConfigName() : "none");
@@ -249,23 +249,63 @@ public class CosmeticsProfile {
         }
     }
 
-    private void UpdateCosmeticsProfile(UltraPlayer ultraPlayer) {
+    /** Updates the CosmeticProfile attached to this UltraPlayer
+     *
+     * @param ultraPlayer the UltraPlayer
+     */
+    private void updateCosmeticsProfile(UltraPlayer ultraPlayer) {
         if (ultraPlayer != null) {
-            this.enabledPet = (ultraPlayer.getCurrentPet() != null) ? ultraPlayer.getCurrentPet().getType() : null;
-            this.enabledEffect = (ultraPlayer.getCurrentParticleEffect() != null) ? ultraPlayer.getCurrentParticleEffect().getType() : null;
-            this.enabledEmote = (ultraPlayer.getCurrentEmote() != null) ? ultraPlayer.getCurrentEmote().getType() : null;
-            this.enabledGadget = (ultraPlayer.getCurrentGadget() != null) ? ultraPlayer.getCurrentGadget().getType() : null;
-            this.enabledHat = (ultraPlayer.getCurrentHat() != null) ? ultraPlayer.getCurrentHat().getType() : null;
-            this.enabledMorph = (ultraPlayer.getCurrentMorph() != null) ? ultraPlayer.getCurrentMorph().getType() : null;
-            this.enabledMount = (ultraPlayer.getCurrentMount() != null) ? (MountType) ultraPlayer.getCurrentMount().getType() : null;
-            this.enabledSuitParts = null;
-            Arrays.asList(ArmorSlot.values()).forEach(armorSlot -> {
-                if (ultraPlayer.getSuit(armorSlot) != null) {
-                    this.enabledSuitParts.put(armorSlot, ultraPlayer.getSuit(armorSlot).getType());
-                }
-            });
+            updatePet(ultraPlayer);
+            updateEffect(ultraPlayer);
+            updateEmote(ultraPlayer);
+            updateGadget(ultraPlayer);
+            updateHat(ultraPlayer);
+            updateMorph(ultraPlayer);
+            updateMount(ultraPlayer);
+            updateSuit(ultraPlayer);
         }
     }
+
+    /**
+     *  Helper functions for updateCosmeticsProfile
+     */
+    private void updatePet(UltraPlayer ultraPlayer) {
+        this.enabledPet = (ultraPlayer.getCurrentPet() != null) ? ultraPlayer.getCurrentPet().getType() : null;
+    }
+
+    private void updateEffect(UltraPlayer ultraPlayer) {
+        this.enabledEffect = (ultraPlayer.getCurrentParticleEffect() != null) ? ultraPlayer.getCurrentParticleEffect().getType() : null;
+    }
+
+    private void updateEmote(UltraPlayer ultraPlayer) {
+        this.enabledEmote = (ultraPlayer.getCurrentEmote() != null) ? ultraPlayer.getCurrentEmote().getType() : null;
+    }
+
+    private void updateGadget(UltraPlayer ultraPlayer) {
+        this.enabledGadget = (ultraPlayer.getCurrentGadget() != null) ? ultraPlayer.getCurrentGadget().getType() : null;
+    }
+
+    private void updateHat(UltraPlayer ultraPlayer) {
+        this.enabledHat = (ultraPlayer.getCurrentHat() != null) ? ultraPlayer.getCurrentHat().getType() : null;
+    }
+
+    private void updateMorph(UltraPlayer ultraPlayer) {
+        this.enabledMorph = (ultraPlayer.getCurrentMorph() != null) ? ultraPlayer.getCurrentMorph().getType() : null;
+    }
+
+    private void updateMount(UltraPlayer ultraPlayer) {
+        this.enabledMount = (ultraPlayer.getCurrentMount() != null) ? (MountType) ultraPlayer.getCurrentMount().getType() : null;
+    }
+
+    private void updateSuit(UltraPlayer ultraPlayer) {
+        this.enabledSuitParts = null;
+        Arrays.asList(ArmorSlot.values()).forEach(armorSlot -> {
+            if (ultraPlayer.getSuit(armorSlot) != null) {
+                this.enabledSuitParts.put(armorSlot, ultraPlayer.getSuit(armorSlot).getType());
+            }
+        });
+    }
+
 
     /**
      * Saves the profile to mysql.

--- a/core/src/main/java/be/isach/ultracosmetics/player/profile/CosmeticsProfile.java
+++ b/core/src/main/java/be/isach/ultracosmetics/player/profile/CosmeticsProfile.java
@@ -3,6 +3,7 @@ package be.isach.ultracosmetics.player.profile;
 import be.isach.ultracosmetics.UltraCosmetics;
 import be.isach.ultracosmetics.UltraCosmeticsData;
 import be.isach.ultracosmetics.config.SettingsManager;
+import be.isach.ultracosmetics.cosmetics.mounts.Mount;
 import be.isach.ultracosmetics.cosmetics.suits.ArmorSlot;
 import be.isach.ultracosmetics.cosmetics.type.*;
 import be.isach.ultracosmetics.log.SmartLogger;
@@ -10,6 +11,7 @@ import be.isach.ultracosmetics.player.UltraPlayer;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -227,6 +229,9 @@ public class CosmeticsProfile {
     public void saveToFile() {
         SettingsManager settingsManager = SettingsManager.getData(uuid);
 
+        // Update the UltraPlayer's cosmetic profile to match current UltraPlayer's settings
+        UpdateCosmeticsProfile(ultraPlayer);
+
         settingsManager.set("enabled.gadget", enabledGadget != null ? enabledGadget.getConfigName() : "none");
         settingsManager.set("enabled.effect", enabledEffect != null ? enabledEffect.getConfigName() : "none");
         settingsManager.set("enabled.emote", enabledEmote != null ? enabledEmote.getConfigName() : "none");
@@ -243,6 +248,24 @@ public class CosmeticsProfile {
         for (ArmorSlot slot : ArmorSlot.values()) {
             SuitType enabledSuitPart = enabledSuitParts.get(slot);
             settingsManager.set("enabled.suit." + slot.toString().toLowerCase(), enabledSuitPart != null ? enabledSuitPart.getConfigName() : "none");
+        }
+    }
+
+    private void UpdateCosmeticsProfile(UltraPlayer ultraPlayer) {
+        if (ultraPlayer != null) {
+            this.enabledPet = (ultraPlayer.getCurrentPet() != null) ? ultraPlayer.getCurrentPet().getType() : null;
+            this.enabledEffect = (ultraPlayer.getCurrentParticleEffect() != null) ? ultraPlayer.getCurrentParticleEffect().getType() : null;
+            this.enabledEmote = (ultraPlayer.getCurrentEmote() != null) ? ultraPlayer.getCurrentEmote().getType() : null;
+            this.enabledGadget = (ultraPlayer.getCurrentGadget() != null) ? ultraPlayer.getCurrentGadget().getType() : null;
+            this.enabledHat = (ultraPlayer.getCurrentHat() != null) ? ultraPlayer.getCurrentHat().getType() : null;
+            this.enabledMorph = (ultraPlayer.getCurrentMorph() != null) ? ultraPlayer.getCurrentMorph().getType() : null;
+            this.enabledMount = (ultraPlayer.getCurrentMount() != null) ? (MountType) ultraPlayer.getCurrentMount().getType() : null;
+            this.enabledSuitParts = null;
+            Arrays.asList(ArmorSlot.values()).forEach(armorSlot -> {
+                if (ultraPlayer.getSuit(armorSlot) != null) {
+                    this.enabledSuitParts.put(armorSlot, ultraPlayer.getSuit(armorSlot).getType());
+                }
+            });
         }
     }
 

--- a/core/src/main/java/be/isach/ultracosmetics/player/profile/CosmeticsProfileManager.java
+++ b/core/src/main/java/be/isach/ultracosmetics/player/profile/CosmeticsProfileManager.java
@@ -51,7 +51,7 @@ public class CosmeticsProfileManager {
 
         // ultraCosmetics.getSmartLogger().write("Successfully created a cosmetics profile for " + up.getUsername());
 
-        cosmeticsProfile.loadToPlayer();
+        cosmeticsProfile.loadToPlayerWithoutSaving();
     }
 
     public CosmeticsProfile getProfile(UltraPlayer ultraPlayer) {


### PR DESCRIPTION
### What is the purpose of this pull request?
_Update a user's cosmetic profile upon losing permissions for a cosmetic._

#### Changes
- [x] When users lose permission for a cosmetic, wipe the cosmetic from their profile.
